### PR TITLE
Test Thread-Safety of Metadata Store #6

### DIFF
--- a/tests/allFileMetadata.py
+++ b/tests/allFileMetadata.py
@@ -1,0 +1,102 @@
+import pytest
+import threading
+from twinTrim.dataStructures.allFileMetadata import AllFileMetadata
+from twinTrim.dataStructures.allFileMetadata import add_or_update_file, store, store_lock
+
+# Mocking the get_file_hash function for different file paths
+def mock_get_file_hash(file_path):
+  return f"hash_{file_path}"
+
+# Reset the store before each test
+@pytest.fixture(autouse=True)
+def reset_store():
+  store.clear()
+
+# Mocking the get_file_hash function for testing so that it doesn't use the actual function
+@pytest.fixture(autouse=True)
+def mock_file_hash_function(monkeypatch):
+  monkeypatch.setattr("twinTrim.dataStructures.allFileMetadata.get_file_hash", mock_get_file_hash)
+
+def test_add_or_update_file_concurrently():
+  "Test that the store remains consistent when multiple threads call add_or_update_file with different file paths concurrently"
+  
+  file_paths = ["file_1", "file_2", "file_3"]
+  
+  # Function to add or update file in the store
+  def worker(file_path):
+    add_or_update_file(file_path)
+    
+  # Create threads for concurrent execution
+  threads = [threading.Thread(target=worker, args=(file_path,)) for file_path in file_paths]
+  
+  # Start all threads
+  for thread in threads:
+    thread.start()
+    
+  # Wait for all threads to finish
+  for thread in threads:
+    thread.join()
+    
+  # Checking that the store contains all the unique file hashes
+  assert len(store) == 3
+  assert "hash_file_1" in store
+  assert "hash_file_2" in store
+  assert "hash_file_3" in store
+  assert store["hash_file_1"].filepath == "file_1"
+  assert store["hash_file_2"].filepath == "file_2"
+  assert store["hash_file_3"].filepath == "file_3"
+  
+def test_add_or_update_file_with_duplicates_concurrently():
+  "Test that the store remains consistent when multiple threads call add_or_update_file with the same file paths concurrently"
+  
+  file_paths = ["file_1", "file_1", "file_1"]
+  
+  # Function to add or update file in the store
+  def worker(file_path):
+    add_or_update_file(file_path)
+    
+  # Create threads for concurrent execution
+  threads = [threading.Thread(target=worker, args=(file_path,)) for file_path in file_paths]
+  
+  # Start all threads
+  for thread in threads:
+    thread.start()
+    
+  # Wait for all threads to finish
+  for thread in threads:
+    thread.join()
+    
+  # Checking that the store contains only one unique file hash
+  assert len(store) == 1
+  assert "hash_file_1" in store
+  assert store["hash_file_1"].filepath == "file_1"
+  
+def test_add_or_update_file_mixed_concurrently():
+  "Test that the store remains consistent when multiple threads call add_or_update_file with both unique and duplicate file paths concurrently"
+  
+  file_paths = ["file_1", "file_1", "file_2", "file_3", "file_3"]
+  
+  # Function to add or update file in the store
+  def worker(file_path):
+    add_or_update_file(file_path)
+    
+  # Create threads for concurrent execution
+  threads = [threading.Thread(target=worker, args=(file_path,)) for file_path in file_paths]
+  
+  # Start all threads
+  for thread in threads:
+    thread.start()
+    
+  # Wait for all threads to finish
+  for thread in threads:
+    thread.join()
+    
+  # Checking that the store contains all the unique file hashes
+  # file_1 and file_3 are duplicates so only one of them should be present in the store
+  assert len(store) == 3
+  assert "hash_file_1" in store
+  assert "hash_file_2" in store
+  assert "hash_file_3" in store
+  assert store["hash_file_1"].filepath == "file_1"
+  assert store["hash_file_2"].filepath == "file_2"
+  assert store["hash_file_3"].filepath == "file_3"


### PR DESCRIPTION
## Description

I have created the allFileMetadata.py in tests folder for the tests of the function add_or_update_file working consistently with multiple threads means if multiple times it is called simultaniously then is it consistent or not using pytest.

- Fixes #6 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [X ] Tests update

## Checklist

- [X ] My code follows the style guidelines of this project
- [X ] I have performed a self-review of my own code
- [X ] I have commented my code, particularly in hard-to-understand areas
- [X ] My changes generate no new warnings
- [ X] New and existing unit tests pass locally with my changes
- [ X] I have maintained a clean commit history by using the necessary Git commands
- [ X] I have checked that my code does not cause any merge conflicts

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/4abaf596-04c1-4e1c-b204-d04ff64b34da)


Add screenshots to help explain the changes (if necessary).

add labels of gssoc 2024 ext and hacktoberfest
