### PR TITLE
Fixes #54 added code of conduct and linked it in readme.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,45 @@
+# Code of Conduct
+
+## My Pledge
+
+As the owner and maintainer of the **TwinTrim** project, I am committed to fostering a welcoming, inclusive, and harassment-free environment for everyone involved. Whether you are contributing code, writing documentation, submitting issues, or participating in discussions, I am dedicated to ensuring that the **TwinTrim** community remains a positive and collaborative space for individuals of all ages, body sizes, visible or invisible disabilities, cultural backgrounds, ethnicities, gender identities and expressions, levels of experience, education, socioeconomic status, nationalities, personal appearances, races, religions, or sexual identities and orientations.
+
+I believe that the strength of the **TwinTrim** project is built on the diversity of perspectives and the collaborative nature of the community. I am actively committed to promoting an atmosphere where everyone feels respected, valued, and heard.
+
+## Standards of Behavior
+
+To help create a positive, productive, and welcoming environment, I expect all participants in the **TwinTrim** project to uphold the following standards of behavior:
+
+### Positive and Respectful Behavior
+
+- **Use inclusive language**: Refrain from discriminatory or exclusionary language. Communications should be accessible and easy to understand for all participants.
+- **Respect differing viewpoints and experiences**: Recognize that others may have different ideas or experiences, and diverse perspectives make the project better.
+- **Accept constructive feedback gracefully**: Feedback is an important part of collaboration. Embrace it with an open mind and focus on improvement.
+- **Focus on the well-being of the project and community**: Prioritize the interests of the project and support fellow contributors.
+- **Show empathy**: Be kind and understanding. Offer support to those who may need it, acknowledging that others may have personal challenges.
+
+### Unacceptable Behavior
+
+Behaviors that violate the values of respect, inclusivity, and professionalism are unacceptable. This includes, but is not limited to:
+
+- **Sexualized language or imagery**: Including inappropriate jokes, comments, or imagery that can make others uncomfortable. Unwelcome advances or attention based on gender are strictly prohibited.
+- **Trolling and derogatory comments**: Verbal attacks, personal insults, or inflammatory comments intended to provoke, belittle, or demean others are unacceptable.
+- **Harassment**: Any form of public or private harassment, bullying, repeated unsolicited communication, or attempts to intimidate are not tolerated.
+- **Publishing private information**: Sharing someone’s personal details, such as their contact information, without their explicit consent is prohibited.
+- **Unprofessional conduct**: Any behavior that is inappropriate in a professional or collaborative setting, including threats or actions that compromise the project’s integrity, will not be tolerated.
+
+## Scope
+
+This Code of Conduct applies to all interactions associated with the **TwinTrim** project, including but not limited to:
+
+- **Project spaces**: This includes all online platforms associated with TwinTrim, such as issue trackers, code repositories, project wikis, and forums.
+- **Public spaces**: The standards set in this Code of Conduct also extend to public spaces where members of the project may be representing **TwinTrim**, such as online conferences, meetups, or social media platforms.
+- **Representation**: An individual is considered to be representing the **TwinTrim** project when they are using an official project email, posting via an official social media account, or acting as a representative at an event.
+
+## Reporting and Resolution
+
+If you encounter or witness any unacceptable behavior or violations of this Code of Conduct, you are encouraged to report them directly to me at [your-email@example.com]. I take all concerns seriously and will take appropriate actions to ensure that the **TwinTrim** community remains a safe and respectful place for all.
+
+## Acknowledgment
+
+I value the contributions of every member of the **TwinTrim** community and am dedicated to leading this project with integrity, inclusivity, and a focus on collaboration. Thank you for being a part of the **TwinTrim** community and for helping make this project a positive experience for everyone!

--- a/README.md
+++ b/README.md
@@ -103,6 +103,14 @@ Contributions are welcome! Whether you have ideas for improving the internal wor
 
 Please refer to the [CONTRIBUTION.md](./CONTRIBUTION.md) for guidelines on how to contribute.
 
+## Code of Conduct
+
+We value and prioritize creating a positive, welcoming, and inclusive environment for everyone involved in the **TwinTrim** project. We encourage all participants to be respectful, collaborative, and supportive of each other.
+
+Please take a moment to review our [Code of Conduct](./CODE_OF_CONDUCT.md) to understand the expected behavior when contributing to the project.
+
+By participating in **TwinTrim**, you agree to abide by these guidelines and help us maintain a healthy, harassment-free community.
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
## Description

This change introduces a **Code of Conduct** to the TwinTrim project, ensuring that all participants in the project adhere to a set of community guidelines promoting respect, inclusivity, and professionalism. It connects the `CODE_OF_CONDUCT.md` file with the project’s `README.md`, informing contributors about its existence and importance.

- Fixes #54 @Kota-Karthik 

## Type of change

- [x] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have maintained a clean commit history by using the necessary Git commands
- [x] I have checked that my code does not cause any merge conflicts

## Screenshots (if applicable)

N/A (Not necessary for this documentation change)