### PR TITLE
Fix issue #3: Correctly mock handle_and_remove in compare_and_replace…

### DIFF
--- a/tests/allFileMetadata_compare_and_replace.py
+++ b/tests/allFileMetadata_compare_and_replace.py
@@ -1,7 +1,6 @@
 import os
 import pytest
 import tempfile
-import time
 from twinTrim.dataStructures.allFileMetadata import AllFileMetadata
 from unittest.mock import patch
 
@@ -21,28 +20,33 @@ def setup_files():
     # Return the paths of the temporary files
     yield temp_file1.name, temp_file2.name
 
-    # Cleanup
-    os.remove(temp_file1.name)
-    os.remove(temp_file2.name)
+    # Cleanup - only remove if the file still exists
+    if os.path.exists(temp_file1.name):
+        os.remove(temp_file1.name)
+    if os.path.exists(temp_file2.name):
+        os.remove(temp_file2.name)
 
 def test_compare_and_replace_removes_correct_file(setup_files):
     file1, file2 = setup_files
 
-    # Modify the modification time of the second file to be newer
-    time.sleep(1)  # Ensure file2 is modified after file1
-    os.utime(file2, None)
+    # Use patch to mock modification times and handle_and_remove function
+    with patch('os.path.getmtime') as mock_getmtime, \
+         patch('twinTrim.dataStructures.allFileMetadata.handle_and_remove') as mock_remove:  
+        
+        # Set mock modification times: file1 older than file2
+        mock_getmtime.side_effect = lambda path: 1000 if path == file1 else 2000
 
-    metadata1 = AllFileMetadata(file1)
-    metadata2 = AllFileMetadata(file2)
+        metadata1 = AllFileMetadata(file1)
+        metadata2 = AllFileMetadata(file2)
 
-    with patch('twinTrim.dataStructures.allFileMetadata.handle_and_remove') as mock_remove:
+        # Execute compare_and_replace
         metadata1.compare_and_replace(metadata2)
 
-        # Check that file1 is removed
+        # Verify that file1 was "removed" since it is older
         mock_remove.assert_called_once_with(file1)
 
 def test_compare_and_replace_no_file_removed_when_file_missing(setup_files):
-    file1, file2 = setup_files
+    file1, _ = setup_files
 
     # Create a metadata object for file1
     metadata1 = AllFileMetadata(file1)
@@ -51,7 +55,7 @@ def test_compare_and_replace_no_file_removed_when_file_missing(setup_files):
     nonexistent_file = 'nonexistent_file.txt'
     metadata2 = AllFileMetadata(nonexistent_file)
 
-    with patch('twinTrim.dataStructures.allFileMetadata.handle_and_remove') as mock_remove:
+    with patch('twinTrim.utils.handle_and_remove') as mock_remove:
         metadata1.compare_and_replace(metadata2)
 
         # Check that no file is removed
@@ -63,18 +67,18 @@ def test_compare_and_replace_no_file_removed_when_both_files_missing(setup_files
     # Create a metadata object for file1
     metadata1 = AllFileMetadata(file1)
 
-    # Create a metadata object for two non-existing files
+    # Create metadata objects for two non-existing files
     nonexistent_file1 = 'nonexistent_file1.txt'
     nonexistent_file2 = 'nonexistent_file2.txt'
     metadata2 = AllFileMetadata(nonexistent_file1)
     metadata3 = AllFileMetadata(nonexistent_file2)
 
-    with patch('twinTrim.dataStructures.allFileMetadata.handle_and_remove') as mock_remove:
+    with patch('twinTrim.utils.handle_and_remove') as mock_remove:
         metadata1.compare_and_replace(metadata2)
         # No file should be removed since the second file doesn't exist
         mock_remove.assert_not_called()
 
-    with patch('twinTrim.dataStructures.allFileMetadata.handle_and_remove') as mock_remove:
+    with patch('twinTrim.utils.handle_and_remove') as mock_remove:
         metadata1.compare_and_replace(metadata3)
         # No file should be removed since the second file doesn't exist
         mock_remove.assert_not_called()


### PR DESCRIPTION
… Tests

## Description

This PR addresses the issue of properly mocking the handle_and_remove function in the compare_and_replace tests to ensure correct test behavior without actually deleting files. This change ensures that the compare_and_replace function behaves as expected in the tests by using a mock for handle_and_remove, resolving the issue where the real function was being called instead of the mock.

- Fixes #3 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Tests update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have maintained a clean commit history by using the necessary Git commands
- [x] I have checked that my code does not cause any merge conflicts

@Kota-Karthik @techy4shri please review PR, and please add labels gssoc-ext, level, hactoberfest-accepted 