### PR TITLE
Fixes #11 Mock file operations Tests

### DIFF
--- a/tests/test_fileMetadata.py
+++ b/tests/test_fileMetadata.py
@@ -1,6 +1,7 @@
 # test_fileMetadata.py
+from unittest.mock import mock_open, patch
 import pytest
-from twinTrim.dataStructures.fileMetadata import FileMetadata
+from twinTrim.dataStructures.fileMetadata import normalStore, add_or_update_normal_file, FileMetadata
 
 def test_insert_new_file():
     # Test inserting a new file into the metadata
@@ -35,3 +36,43 @@ def test_insert_multiple_files():
     assert len(metadata.filepaths) == 2
     assert file_path1 in metadata.filepaths
     assert file_path2 in metadata.filepaths
+
+def test_add_or_update_new_file():
+    file_path = "C:\\Users\\2004s\\Desktop\\dummy\\dummy_5.txt"  # Define the mock file path
+    expected_file_hash = "b1295d8ebb927df19ad74eec6aea72e3"  # Use the actual hash computed from the file
+
+    # Mock the get_file_hash function to return the expected hash
+    with patch("twinTrim.utils.get_file_hash", return_value=expected_file_hash), \
+         patch("builtins.open", mock_open(read_data=b"some binary content")):
+
+        # Clear normalStore before the test to avoid conflicts
+        normalStore.clear()
+
+        # Call the function to add a new file
+        add_or_update_normal_file(file_path)
+
+        # Check that the expected file hash is in normalStore
+        assert expected_file_hash in normalStore.keys(), f"Expected hash '{expected_file_hash}' not found in normalStore"
+
+        # Check that the file path was added correctly
+        assert normalStore[expected_file_hash].filepaths == [file_path], "File path not added correctly"
+
+def test_add_or_update_existing_file():
+    file_path1 = "C:\\Users\\2004s\\Desktop\\dummy\\dummy_5.txt"
+    file_path2 = "C:\\Users\\2004s\\Desktop\\dummy\\dummy_5_v2.txt"
+    expected_file_hash = "b1295d8ebb927df19ad74eec6aea72e3"  # Use the actual hash computed from the file
+
+    # First add a file
+    with patch("twinTrim.utils.get_file_hash", return_value=expected_file_hash), \
+         patch("builtins.open", mock_open(read_data=b"some binary content")):
+        normalStore.clear()
+        add_or_update_normal_file(file_path1)
+
+    # Then update it
+    with patch("twinTrim.utils.get_file_hash", return_value=expected_file_hash), \
+         patch("builtins.open", mock_open(read_data=b"some binary content")):
+        add_or_update_normal_file(file_path2)
+
+    # Check that the file paths were updated correctly
+    assert expected_file_hash in normalStore.keys(), f"Expected hash '{expected_file_hash}' not found in normalStore"
+    assert normalStore[expected_file_hash].filepaths == [file_path1, file_path2], "File paths not updated correctly"


### PR DESCRIPTION
## Description
This pull request addresses issue #11 by adding tests for the add_or_update_normal_file function in twinTrim/dataStructures/fileMetadata.py. The objective is to mock file operations, such as file access, to simulate various file system behaviors, including scenarios where files exist and do not. This ensures that the function behaves as expected without relying on the actual file system, thus improving test reliability and speed.

- Fixes #11 

## Type of change
- Implemented mocking for file access in the tests using `pytest` to simulate different file scenarios.
- Created specific test cases that cover:
  - Adding a new file when it does not exist in the `normalStore`.
  - Updating existing file metadata when a file already exists.
- Verified that the function handles these cases correctly without performing actual file operations.

These changes enhance the test suite's coverage and ensure that the `add_or_update_normal_file` function is robust against various file system states.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have maintained a clean commit history by using the necessary Git commands
- [x] I have checked that my code does not cause any merge conflicts

## Screenshots (if applicable)

No screenshots are necessary for this update.

