### PR TITLE
Added normalised expected path to tackle windows specific error.

### DIFF
--- a/tests/test_flagController.py
+++ b/tests/test_flagController.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 from unittest.mock import patch, MagicMock
 from twinTrim.flagController import handleAllFlag
@@ -29,7 +30,7 @@ def test_handle_all_flag_filtered_files(mock_progress_bar, mock_add_or_update_fi
     """Test handleAllFlag with files that pass the filter."""
     # Simulate a directory with 3 files
     mock_os_walk.return_value = [
-        ('/path/to/files', [], ['file1.txt', 'file2.txt', 'file3.txt'])
+        (os.path.normpath('/path/to/files'), [], ['file1.txt', 'file2.txt', 'file3.txt'])
     ]
     
     # Mock file_filter to filter out some files
@@ -40,10 +41,13 @@ def test_handle_all_flag_filtered_files(mock_progress_bar, mock_add_or_update_fi
     mock_progress_bar.return_value.__enter__.return_value = MagicMock()
 
     # Call the function
-    handleAllFlag('/path/to/files', mock_file_filter, 'yellow', 'white')
-
+    handleAllFlag(os.path.normpath('/path/to/files'), mock_file_filter, 'yellow', 'white')
+    
+    # Normalizing the expected file path to handle platform-specific slashes (Windows != \\)
+    expected_path = os.path.normpath('/path/to/files/file2.txt')
+    
     # Assertions
-    mock_add_or_update_file.assert_called_once_with('/path/to/files/file2.txt')  # Only file2.txt should be processed
+    mock_add_or_update_file.assert_called_once_with(expected_path)  # Only file2.txt should be processed
     mock_progress_bar.assert_called_once()  # Progress bar should still be created
 
 
@@ -54,7 +58,7 @@ def test_handle_all_flag_success(mock_progress_bar, mock_add_or_update_file, moc
     """Test handleAllFlag successful execution."""
     # Simulate a directory with 3 files
     mock_os_walk.return_value = [
-        ('/path/to/files', [], ['file1.txt', 'file2.txt', 'file3.txt'])
+        (os.path.normpath('/path/to/files'), [], ['file1.txt', 'file2.txt', 'file3.txt'])
     ]
     
     # Mock file_filter to allow all files
@@ -65,7 +69,7 @@ def test_handle_all_flag_success(mock_progress_bar, mock_add_or_update_file, moc
     mock_progress_bar.return_value.__enter__.return_value = MagicMock()
 
     # Call the function
-    handleAllFlag('/path/to/files', mock_file_filter, 'yellow', 'white')
+    handleAllFlag(os.path.normpath('/path/to/files'), mock_file_filter, 'yellow', 'white')
 
     # Assertions
     assert mock_add_or_update_file.call_count == 3  # All 3 files should be processed


### PR DESCRIPTION
## Description

Used path normalization of OS lib in Python  `os.path.normpath()` to normalize the path by converting it into the correct format based on the operating system (backslashes for Windows, forward slashes for Unix-based systems).

This ensures both the expected and actual values in the test are comparable, no matter which platform the test is being run on and all tests pass without any error.

- Fixes #157 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
- [X] I have maintained a clean commit history by using the necessary Git commands
- [X] I have checked that my code does not cause any merge conflicts

## Screenshots (if applicable)

BEFORE:
![Screenshot 2024-10-27 195331](https://github.com/user-attachments/assets/29b07d33-d7a9-48a1-9a40-0b8a92cb8d41)

AFTER:
![Screenshot 2024-10-28 164120](https://github.com/user-attachments/assets/cbf59ab3-d63b-40ca-ae36-7fd478c5acce)

